### PR TITLE
Properly return the first 10 towns in the list

### DIFF
--- a/server/api/towns/index.ts
+++ b/server/api/towns/index.ts
@@ -32,7 +32,7 @@ class TownsAPIRoute extends api.Route<{
 	}
 
 	get skip() {
-		return this.page === 1 ? 0 : this.page * this.take
+		return this.page === 0 ? 0 : (this.page - 1) * this.take
 	}
 
 	get idsOnly() {

--- a/server/api/towns/index.ts
+++ b/server/api/towns/index.ts
@@ -32,7 +32,7 @@ class TownsAPIRoute extends api.Route<{
 	}
 
 	get skip() {
-		return this.page === 0 ? 0 : (this.page - 1) * this.take
+		return this.page <= 0 ? 0 : (this.page - 1) * this.take
 	}
 
 	get idsOnly() {


### PR DESCRIPTION
Some towns (10, specifically) are missing from the towns list page due to a faulty check in the skip() method. It basically didn't account for the first page so the first 10 towns were always missing from the list. Closes #17